### PR TITLE
added new model grid f05_f05_mn0253

### DIFF
--- a/component_grids_nuopc.xml
+++ b/component_grids_nuopc.xml
@@ -33,6 +33,11 @@
     <mesh>$DIN_LOC_ROOT/share/meshes/0.125nldas2_ESMFmesh_cd5_241220.nc</mesh>
     <desc>Regional NLDAS-2 grid over the U.S. (0.125 degree resolution; 25-53N, 235-293E)</desc>
   </domain>
+  <domain name="0.47x0.63">
+    <nx>576</nx> <ny>384</ny>
+    <mesh>$DIN_LOC_ROOT/share/meshes/fv0.47x0.63_141008_FIX102722_polemod_ESMFMesh.nc</mesh>
+    <desc>0.47x0.63 is FV 1/2-deg grid:</desc>
+  </domain>
   <domain name="0.9x1.25">
     <nx>288</nx>  <ny>192</ny>
     <!-- This is needed for PTS_MODE - it specifies the xml variable PTS_DOMAINFILE -->
@@ -307,6 +312,12 @@
     <nx>320</nx>  <ny>384</ny>
     <mesh>$DIN_LOC_ROOT/share/meshes/gx1v7_151008_ESMFmesh.nc</mesh>
     <desc>gx1v7 is displaced Greenland pole 1-deg grid with Caspian as a land feature:</desc>
+  </domain>
+  <domain name="tn0.25v3">
+    <nx>1440</nx>  <ny>1050</ny>
+<!--    <mesh>$DIN_LOC_ROOT/share/meshes/tn0.25v3_160721_ESMFmesh.nc</mesh> -->
+    <mesh>$DIN_LOC_ROOT/share/scripgrids/tn0.25v3_160721.nc</mesh>
+    <desc>tn0.25v3 is NEMO ORCA1 tripole grid at 1/4 deg (reduced eORCA):</desc>
   </domain>
   <domain name="gx3v7">
     <nx>100</nx> <ny>116</ny>

--- a/component_grids_nuopc.xml
+++ b/component_grids_nuopc.xml
@@ -308,6 +308,12 @@
     <mesh>$DIN_LOC_ROOT/share/meshes/gx1v7_151008_ESMFmesh.nc</mesh>
     <desc>gx1v7 is displaced Greenland pole 1-deg grid with Caspian as a land feature:</desc>
   </domain>
+  <domain name="tn0.25v3">
+    <nx>1440</nx>  <ny>1050</ny>
+<!--    <mesh>$DIN_LOC_ROOT/share/meshes/tn0.25v3_160721_ESMFmesh.nc</mesh> -->
+    <mesh>$DIN_LOC_ROOT/share/scripgrids/tn0.25v3_160721.nc</mesh>
+    <desc>tn0.25v3 is NEMO ORCA1 tripole grid at 1/4 deg (reduced eORCA):</desc>
+  </domain>
   <domain name="gx3v7">
     <nx>100</nx> <ny>116</ny>
     <mesh>$DIN_LOC_ROOT/share/meshes/gx3v7_120309_ESMFmesh.nc</mesh>

--- a/component_grids_nuopc.xml
+++ b/component_grids_nuopc.xml
@@ -67,11 +67,6 @@
     <desc>10x15 is FV 10-deg grid:</desc>
     <support>For low resolution testing</support>
   </domain>
-  <domain name="0.47x0.63">
-    <nx>576</nx> <ny>384</ny>
-    <mesh>$DIN_LOC_ROOT/share/meshes/fv0.47x0.63_141008_ESMFmesh.nc</mesh>
-    <desc>0.47x0.63 is FV 0.5-deg grid:</desc>
-  </domain>
   <domain name="T5">
     <nx>16</nx> <ny>8</ny>
     <mesh>$DIN_LOC_ROOT/share/meshes/T5_ESMFmesh_cdf5_c20210923.nc</mesh>

--- a/machines/config_batch.xml
+++ b/machines/config_batch.xml
@@ -768,7 +768,7 @@
       <arg flag="-x" />
     </submit_args>
     <directives>
-      <directive                       > -R "span[ptile=30]"</directive>
+      <directive                       > -R "span[ptile={{ tasks_per_node }}]"</directive>
     </directives>
     <queues>
       <queue walltimemin="00:00" walltimemax="02:00" default="true">p_short</queue>

--- a/machines/config_batch.xml
+++ b/machines/config_batch.xml
@@ -749,19 +749,13 @@
   <batch_system MACH="zeus" type="lsf">
     <batch_env>-env</batch_env>
     <submit_args>
-<<<<<<< HEAD
-      <argument> -q $JOB_QUEUE </argument>
-      <argument> -W $JOB_WALLCLOCK_TIME </argument>
-      <argument> -P $PROJECT </argument>
-=======
       <arg flag="-q" name="$JOB_QUEUE"/>
       <arg flag="-W" name="$JOB_WALLCLOCK_TIME"/>
       <arg flag="-P" name="$PROJECT"/>
       <arg flag="-x" />
->>>>>>> a864944cc2da07c8a4493fc7346f5010b24a9431
     </submit_args>
     <directives>
-      <directive                       > -R "span[ptile=30]"</directive>
+      <directive                       > -R "span[ptile={{ tasks_per_node }}]"</directive>
     </directives>
     <queues>
       <queue walltimemin="00:00" walltimemax="02:00" default="true">p_short</queue>

--- a/machines/config_batch.xml
+++ b/machines/config_batch.xml
@@ -765,9 +765,10 @@
       <arg flag="-q" name="$JOB_QUEUE"/>
       <arg flag="-W" name="$JOB_WALLCLOCK_TIME"/>
       <arg flag="-P" name="$PROJECT"/>
+      <arg flag="-x" />
     </submit_args>
     <directives>
-      <directive                       > -R "span[ptile={{ tasks_per_node }}]"</directive>
+      <directive                       > -R "span[ptile=30]"</directive>
     </directives>
     <queues>
       <queue walltimemin="00:00" walltimemax="02:00" default="true">p_short</queue>

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -3613,16 +3613,16 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">impi20.1/parallel-netcdf/1.12.1</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="TRUE">
-        <command name="load">impi20.1/esmf/8.1.1-intelmpi-64-g</command>
+        <command name="load">impi20.1/esmf/8.2.0-intelmpi-64-g</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="FALSE">
-        <command name="load">impi20.1/esmf/8.1.1-intelmpi-64-O</command>
+        <command name="load">impi20.1/esmf/8.2.0-intelmpi-64-O</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="TRUE">
-        <command name="load">intel20.1/esmf/8.1.1-mpiuni-64-g</command>
+        <command name="load">intel20.1/esmf/8.2.0-mpiuni-64-g</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="FALSE">
-        <command name="load">intel20.1/esmf/8.1.1-mpiuni-64-O</command>
+        <command name="load">intel20.1/esmf/8.2.0-mpiuni-64-O</command>
       </modules>
     </module_system>
     <environment_variables>

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -3589,7 +3589,7 @@ This allows using a different mpirun command to launch unit tests
 
   <machine MACH="zeus">
     <DESC> CMCC Lenovo ThinkSystem SD530, os is Linux, 36 pes/node, batch system is LSF</DESC>
-    <NODENAME_REGEX>(login[1,2]-ib|n[0-9][0-9][0-9]-ib)</NODENAME_REGEX>
+    <NODENAME_REGEX>(login[1,2].cluster.net|n[0-9][0-9][0-9].cluster.net)</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>intel</COMPILERS>
     <MPILIBS>impi,mpi-serial</MPILIBS>
@@ -3639,20 +3639,24 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">impi20.1/parallel-netcdf/1.12.1</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="TRUE">
-        <command name="load">impi20.1/esmf/8.1.1-intelmpi-64-g</command>
+        <command name="load">impi20.1/esmf/8.2.0-intelmpi-64-g</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="FALSE">
-        <command name="load">impi20.1/esmf/8.1.1-intelmpi-64-O</command>
+        <command name="load">impi20.1/esmf/8.2.0-intelmpi-64-O</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="TRUE">
-        <command name="load">intel20.1/esmf/8.1.1-mpiuni-64-g</command>
+        <command name="load">intel20.1/esmf/8.2.0-mpiuni-64-g</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="FALSE">
-        <command name="load">intel20.1/esmf/8.1.1-mpiuni-64-O</command>
+        <command name="load">intel20.1/esmf/8.2.0-mpiuni-64-O</command>
       </modules>
     </module_system>
     <environment_variables>
       <env name="XIOS_PATH">/data/inputs/CESM/xios-2.5</env>
+    </environment_variables>
+    <environment_variables comp_interface="nuopc">
+      <env name="ESMF_RUNTIME_PROFILE">ON</env>
+      <env name="ESMF_RUNTIME_PROFILE_OUTPUT">SUMMARY</env>
     </environment_variables>
     <environment_variables compiler="intel">
       <env name="I_MPI_EXTRA_FILESYSTEM">1</env>

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -3605,7 +3605,7 @@ This allows using a different mpirun command to launch unit tests
     <BATCH_SYSTEM>lsf</BATCH_SYSTEM>
     <SUPPORTED_BY>cmcc</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>72</MAX_TASKS_PER_NODE>
-    <MAX_MPITASKS_PER_NODE>36</MAX_MPITASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>30</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
       <executable> mpirun </executable>

--- a/maps_nuopc.xml
+++ b/maps_nuopc.xml
@@ -18,6 +18,10 @@
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_gx1v7_nn_open_ocean_nnsm_e1000r300_marginal_sea_170413.nc</map>
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_gx1v7_nnsm_e1000r300_170413.nc</map>
     </gridmap>
+    <gridmap rof_grid="rx1" ocn_grid="tn0.25v3" >
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_tn0.25v3_e1000r300_160721.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_tn0.25v3_e1000r300_160721.nc</map>
+    </gridmap>
     <gridmap rof_grid="rx1" ocn_grid="tx1v1" >
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_tx1v1_e1000r300_161214.nc</map>
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_tx1v1_e1000r300_161214.nc</map>
@@ -45,6 +49,10 @@
     <gridmap rof_grid="r05" ocn_grid="gx1v7" >
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v7_nn_open_ocean_nnsm_e1000r300_marginal_sea_170413.nc</map>
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v7_nnsm_e1000r300_170413.nc</map>
+    </gridmap>
+    <gridmap rof_grid="r05" ocn_grid="tn0.25v3" >
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_tn0.25v3_e1000r300_160721.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_tn0.25v3_e1000r300_160721.nc</map>
     </gridmap>
     <gridmap rof_grid="r05" ocn_grid="tx1v1" >
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_tx1v1_e1000r500_161214.nc</map>

--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -489,6 +489,13 @@
     <mask>gx1v7</mask>
   </model_grid>
 
+  <model_grid alias="f05_n0253">
+    <grid name="atm">0.47x0.63</grid>
+    <grid name="lnd">0.47x0.63</grid>
+    <grid name="ocnice">tn0.25v3</grid>
+    <mask>tn0.25v3</mask>
+  </model_grid>
+
   <model_grid alias="f05_t12">
     <grid name="atm">0.47x0.63</grid>
     <grid name="lnd">0.47x0.63</grid>
@@ -831,6 +838,13 @@
     <mask>gx1v7</mask>
   </model_grid>
 
+  <model_grid alias="ne30_n0253">
+    <grid name="atm">ne30np4</grid>
+    <grid name="lnd">ne30np4</grid>
+    <grid name="ocnice">tn0.25v3</grid>
+    <mask>tn0.25v3</mask>
+  </model_grid>
+
   <model_grid alias="ne30pg3_g17">
     <grid name="atm">ne30np4.pg3</grid>
     <grid name="lnd">ne30np4.pg3</grid>
@@ -896,6 +910,13 @@
     <grid name="lnd">ne60np4</grid>
     <grid name="ocnice">gx1v7</grid>
     <mask>gx1v7</mask>
+  </model_grid>
+
+  <model_grid alias="ne60_n0253">
+    <grid name="atm">ne60np4</grid>
+    <grid name="lnd">ne60np4</grid>
+    <grid name="ocnice">tn0.25v3</grid>
+    <mask>tn0.25v3</mask>
   </model_grid>
 
   <model_grid alias="ne60_ne60_mg16" not_compset="_POP">

--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -624,6 +624,13 @@
     <mask>gx1v7</mask>
   </model_grid>
 
+  <model_grid alias="f05_f05_mn0253">
+    <grid name="atm">0.47x0.63</grid>
+    <grid name="lnd">0.47x0.63</grid>
+    <grid name="ocnice">0.47x0.63</grid>
+    <mask>tn0.25v3</mask>
+  </model_grid>
+
   <model_grid alias="f19_g16">
     <grid name="atm">1.9x2.5</grid>
     <grid name="lnd">1.9x2.5</grid>


### PR DESCRIPTION
This provides the same ocean mask for F compsets  as the fully prognostic B compsets use in CMCC configurations.

Resolves issue #2 