### PR TITLE
Add rebuild nemo in the workflow and its template

### DIFF
--- a/machines/config_workflow.xml
+++ b/machines/config_workflow.xml
@@ -48,6 +48,16 @@
 	<walltime>0:20:00</walltime>
       </runtime_parameters>
     </job>
+    <job name="case.nemo_rebuild">
+      <template>template.nemo_rebuild4cmcc-cm</template>
+      <dependency>case.st_archive</dependency>
+      <prereq>$NEMO_REBUILD</prereq>
+      <runtime_parameters MACH="juno">
+                <task_count>1</task_count>
+                <tasks_per_node>1</tasks_per_node>
+                <walltime>1:00:00</walltime>
+      </runtime_parameters>
+    </job>
   </workflow_jobs>
 
   <workflow_jobs id="timeseries" prepend="default">

--- a/machines/template.nemo_rebuild4cmcc-cm
+++ b/machines/template.nemo_rebuild4cmcc-cm
@@ -1,0 +1,41 @@
+#!/usr/bin/bash -l
+{{ batchdirectives }}
+#. ~/.bashrc
+
+# activate needed env
+module purge
+module load anaconda
+conda activate nemo_rebuild
+module load --auto oneapi-2022.1.0/compiler-rt/2022.1.0 intel-2021.6.0/2021.6.0 impi-2021.6.0/2021.6.0 intel-2021.6.0/curl/7.85.0-djjip intel-2021.6.0/cmake/3.25.1-7wfsx intel-2021.6.0/perl/5.36.0-jj4hw intel-2021.6.0/perl-xml-libxml/2.0201-shybf intel-2021.6.0/xerces-c/3.2.3-witnt oneapi-2022.1.0/tbb/2021.6.0 oneapi-2022.1.0/mkl/2022.1.0 intel-2021.6.0/impi-2021.6.0/hdf5/1.13.3-76cip intel-2021.6.0/impi-2021.6.0/netcdf-c/4.9.0-qbuoy intel-2021.6.0/impi-2021.6.0/netcdf-fortran/4.6.0-gohn7 intel-2021.6.0/impi-2021.6.0/parallel-netcdf/1.12.3-eshb5 intel-2021.6.0/impi-2021.6.0/xios/2.5-36kwn intel-2021.6.0/impi-2021.6.0/parallelio/2.6.0-tc4q3 intel-2021.6.0/impi-2021.6.0/esmf/8.4.2-pioext_2.6.0-dnjmu intel-2021.6.0/impi-2021.6.0/parmetis/4.0.3-ocsgn
+
+set -euvx
+CASEROOT={{ caseroot }}
+cd $CASEROOT
+#get case name and cores dedicated to ocean model from xml files
+CASE=`./xmlquery CASE|cut -d ':' -f2|sed 's/ //g'`
+NTASK=`./xmlquery NTASKS_OCN |cut -d ':' -f2|sed 's/ //g'`
+# this is the number of parallel postprocessing you want to set
+N=$((NTASK/10))
+CIME_OUTPUT_ROOT=`./xmlquery CIME_OUTPUT_ROOT|cut -d ':' -f2|sed 's/ //g'`
+NEMO_REBUILD_ROOT=`./xmlquery NEMO_REBUILD_ROOT|cut -d ':' -f2|sed 's/ //g'`
+# add your frequencies and grids. The script skip them if not present
+for frq in 1m 1d
+do 
+   for grd in T U V W 
+   do
+      nfile=`ls $CIME_OUTPUT_ROOT/archive/$CASE/ocn/hist/${CASE}_${frq}_*grid_${grd}_0000.nc|wc -l`
+      if [[ $nfile -eq 0 ]]
+      then
+         continue
+      fi  
+# this should be independent from expID and general
+      data_now=`ls -t $CIME_OUTPUT_ROOT/archive/$CASE/ocn/hist/${CASE}_${frq}_*grid_${grd}_0000.nc|tail -1|rev|cut -d '_' -f4-5|rev`
+      mpirun -n $N python -m mpi4py $NEMO_REBUILD_ROOT/py_nemo_rebuild/src/py_nemo_rebuild/nemo_rebuild.py -i $CIME_OUTPUT_ROOT/archive/$CASE/ocn/hist/${CASE}_${frq}_${data_now}_grid_${grd}
+      stat=$?
+# if correctly merged remove single files
+      if [[ $stat -eq 0 ]]
+      then
+         rm $CIME_OUTPUT_ROOT/archive/$CASE/ocn/hist/${CASE}_${frq}_${data_now}_grid_${grd}_0???.nc
+      fi
+   done
+done

--- a/machines/template.nemo_rebuild4cmcc-cm
+++ b/machines/template.nemo_rebuild4cmcc-cm
@@ -14,7 +14,7 @@ cd $CASEROOT
 #get case name and cores dedicated to ocean model from xml files
 CASE=`./xmlquery CASE|cut -d ':' -f2|sed 's/ //g'`
 NTASK=`./xmlquery NTASKS_OCN |cut -d ':' -f2|sed 's/ //g'`
-# this is the number of parallel postprocessing you want to set
+# this is the number of parallel postprocessign you want to set and must be a an integer
 N=$((NTASK/10))
 CIME_OUTPUT_ROOT=`./xmlquery CIME_OUTPUT_ROOT|cut -d ':' -f2|sed 's/ //g'`
 NEMO_REBUILD_ROOT=`./xmlquery NEMO_REBUILD_ROOT|cut -d ':' -f2|sed 's/ //g'`


### PR DESCRIPTION
Add the specific job for rebuilding the nemo output in multiple_file format.
This option is driven by the NEMO_REBUILD flag.
Add the template for the nemo rebuild job.